### PR TITLE
The package python-pip doesn't exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     build-essential \
     python-dev \
-    python-pip \
+    python3-pip \
     nodejs \
     npm
 


### PR DESCRIPTION
Since python2.7 is retired https://pythonclock.org/. Probably ubuntu removed python-pip and kept only python3-pip